### PR TITLE
Feature/GUUI-3675-storage-info-slider

### DIFF
--- a/src/components/Plot/Storage/StorageItem.module.css
+++ b/src/components/Plot/Storage/StorageItem.module.css
@@ -1,5 +1,9 @@
 h2.item-label {
   font-weight: bold;
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .button-group {

--- a/src/components/Plot/Storage/StorageItem.tsx
+++ b/src/components/Plot/Storage/StorageItem.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { IonButton, IonIcon, IonItem, IonLabel, IonText } from "@ionic/react";
-import { trash } from "ionicons/icons";
+import { trash, informationCircleOutline } from "ionicons/icons";
 
 import { DataParams, VariableDbEntry } from "../../../types/time-series.types";
 import { extractLatLonFromCacheKey } from "../helpers";
@@ -13,15 +13,17 @@ interface StorageItemProps {
   item: Partial<VariableDbEntry>;
   onDelete: (key: string) => void;
   onPlot: ({ lat, lon, begin_time, end_time, variable }: DataParams) => void;
+  onRequestInfo: (dataFieldId: string) => void;
 }
 
 const StorageItem: React.FC<StorageItemProps> = ({
   item,
   onDelete,
   onPlot,
+  onRequestInfo,
 }) => {
   const itemMetadataFromCatalog = catalog.find(
-    (data) => data.dataFieldId === item.variableEntryId
+    (data) => data.dataFieldId === item.variableEntryId,
   );
 
   const plotCachedItemHandler = () => {
@@ -42,12 +44,29 @@ const StorageItem: React.FC<StorageItemProps> = ({
     onPlot(cachedDataParams);
   };
 
+  // TODO: refactor??? IonButton onClick
   return (
     <IonItem>
       <IonLabel className="ion-padding-top">
         <IonText>
           <h2 className={styles["item-label"]}>
             {itemMetadataFromCatalog?.label}
+            <IonButton
+              style={{ marginLeft: "16px" }}
+              size="small"
+              fill="clear"
+              onClick={(e) => {
+                // e.stopPropagation();
+                if (!itemMetadataFromCatalog) return;
+                onRequestInfo(itemMetadataFromCatalog.dataFieldId);
+              }}
+            >
+              <IonIcon
+                aria-hidden="true"
+                size="large"
+                icon={informationCircleOutline}
+              />
+            </IonButton>
           </h2>
           {item.metadata?.Request_time && (
             <p>Timestamp: {toLocalShortDateTime(item.metadata.Request_time)}</p>

--- a/src/components/Plot/Storage/StorageItem.tsx
+++ b/src/components/Plot/Storage/StorageItem.tsx
@@ -1,10 +1,6 @@
 import React from "react";
 import { IonButton, IonIcon, IonItem, IonLabel, IonText } from "@ionic/react";
-import {
-  trash,
-  informationCircleOutline,
-  notificationsOff,
-} from "ionicons/icons";
+import { trash, informationCircleOutline } from "ionicons/icons";
 
 import { DataParams, VariableDbEntry } from "../../../types/time-series.types";
 import { extractLatLonFromCacheKey } from "../helpers";

--- a/src/components/Plot/Storage/StorageItem.tsx
+++ b/src/components/Plot/Storage/StorageItem.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import { IonButton, IonIcon, IonItem, IonLabel, IonText } from "@ionic/react";
-import { trash, informationCircleOutline } from "ionicons/icons";
+import {
+  trash,
+  informationCircleOutline,
+  notificationsOff,
+} from "ionicons/icons";
 
 import { DataParams, VariableDbEntry } from "../../../types/time-series.types";
 import { extractLatLonFromCacheKey } from "../helpers";
@@ -23,7 +27,7 @@ const StorageItem: React.FC<StorageItemProps> = ({
   onRequestInfo,
 }) => {
   const itemMetadataFromCatalog = catalog.find(
-    (data) => data.dataFieldId === item.variableEntryId,
+    (data) => data.dataFieldId === item.variableEntryId
   );
 
   const plotCachedItemHandler = () => {
@@ -44,22 +48,18 @@ const StorageItem: React.FC<StorageItemProps> = ({
     onPlot(cachedDataParams);
   };
 
-  // TODO: refactor??? IonButton onClick
+  const infoButtonHandler = () => {
+    if (!itemMetadataFromCatalog) return;
+    onRequestInfo(itemMetadataFromCatalog.dataFieldId);
+  };
+
   return (
     <IonItem>
       <IonLabel className="ion-padding-top">
         <IonText>
           <h2 className={styles["item-label"]}>
             {itemMetadataFromCatalog?.label}
-            <IonButton
-              style={{ marginLeft: "16px" }}
-              size="small"
-              fill="clear"
-              onClick={(e) => {
-                if (!itemMetadataFromCatalog) return;
-                onRequestInfo(itemMetadataFromCatalog.dataFieldId);
-              }}
-            >
+            <IonButton size="small" fill="clear" onClick={infoButtonHandler}>
               <IonIcon
                 aria-hidden="true"
                 size="large"

--- a/src/components/Plot/Storage/StorageItem.tsx
+++ b/src/components/Plot/Storage/StorageItem.tsx
@@ -56,7 +56,6 @@ const StorageItem: React.FC<StorageItemProps> = ({
               size="small"
               fill="clear"
               onClick={(e) => {
-                // e.stopPropagation();
                 if (!itemMetadataFromCatalog) return;
                 onRequestInfo(itemMetadataFromCatalog.dataFieldId);
               }}

--- a/src/components/Plot/Storage/StorageManager.tsx
+++ b/src/components/Plot/Storage/StorageManager.tsx
@@ -24,6 +24,7 @@ import {
 import useCheckIndexedDBUsage from "../../../hooks/useCheckIndexedDBUsage";
 
 import StorageItem from "./StorageItem";
+import InfoPanel from "../../UI/InfoPanel";
 
 interface StorageManagerProps {
   onPlot: (newParams: DataParams) => void;
@@ -45,7 +46,7 @@ const StorageManager: React.FC<StorageManagerProps> = ({
   } = useCheckIndexedDBUsage();
 
   const [cachedItems, setCachedItems] = useState<Partial<VariableDbEntry>[]>(
-    []
+    [],
   );
   const [presentToast, dismissToast] = useIonToast();
   const [presentAlert] = useIonAlert();
@@ -62,7 +63,7 @@ const StorageManager: React.FC<StorageManagerProps> = ({
   const toastPresenter = (
     message: string,
     position: "top" | "middle" | "bottom",
-    color: "success" | "danger"
+    color: "success" | "danger",
   ) => {
     presentToast({
       message: message,
@@ -78,7 +79,7 @@ const StorageManager: React.FC<StorageManagerProps> = ({
     message?: string,
     subHeader?: string,
     cancel?: () => void,
-    confirm?: (item?: string) => void
+    confirm?: (item?: string) => void,
   ) => {
     presentAlert({
       header: header,
@@ -112,7 +113,7 @@ const StorageManager: React.FC<StorageManagerProps> = ({
       toastPresenter(
         "Something went wrong while retrieving cached data!",
         "top",
-        "danger"
+        "danger",
       );
     }
   };
@@ -132,7 +133,7 @@ const StorageManager: React.FC<StorageManagerProps> = ({
       toastPresenter(
         "Something went wrong while deleting an item!",
         "top",
-        "danger"
+        "danger",
       );
     }
   };
@@ -148,9 +149,14 @@ const StorageManager: React.FC<StorageManagerProps> = ({
       toastPresenter(
         "Something went wrong while deleting items!",
         "top",
-        "danger"
+        "danger",
       );
     }
+  };
+
+  const variableInfoHandler = (dataFieldId: string) => {
+    return;
+    // setVariableId(dataFieldId);
   };
 
   const displayCachedItems = () => {
@@ -173,9 +179,10 @@ const StorageManager: React.FC<StorageManagerProps> = ({
               undefined,
               undefined,
               undefined,
-              () => item.key && deleteCachedItemHandler(item.key)
+              () => item.key && deleteCachedItemHandler(item.key),
             );
           }}
+          onRequestInfo={variableInfoHandler}
         />
       );
     });
@@ -192,6 +199,11 @@ const StorageManager: React.FC<StorageManagerProps> = ({
         </IonToolbar>
       </IonHeader>
       <IonContent className="ion-padding">
+        {/* <InfoPanel
+          // dataList={variableInfo}
+          // isOpen={!!variableId}
+          // afterDismiss={afterInfoPanelDismiss}
+        /> */}
         <IonCol>
           {usedSpace && totalSpace && (
             <div>
@@ -210,7 +222,7 @@ const StorageManager: React.FC<StorageManagerProps> = ({
                   undefined,
                   undefined,
                   undefined,
-                  deleteAllItemsHandler
+                  deleteAllItemsHandler,
                 )
               }
               disabled={!cachedItems.length}

--- a/src/components/Plot/Storage/StorageManager.tsx
+++ b/src/components/Plot/Storage/StorageManager.tsx
@@ -25,6 +25,8 @@ import useCheckIndexedDBUsage from "../../../hooks/useCheckIndexedDBUsage";
 
 import StorageItem from "./StorageItem";
 import InfoPanel from "../../UI/InfoPanel";
+import { useCatalogQuery } from "../../../data/useCatalogQuery";
+import { getDate } from "../../../utils/date";
 
 interface StorageManagerProps {
   onPlot: (newParams: DataParams) => void;
@@ -50,6 +52,61 @@ const StorageManager: React.FC<StorageManagerProps> = ({
   );
   const [presentToast, dismissToast] = useIonToast();
   const [presentAlert] = useIonAlert();
+
+  const { data: catalog, isLoading, isFetching } = useCatalogQuery();
+  const [variableId, setVariableId] = useState("");
+  const currentVariable = catalog?.find(
+    (data) => data.dataFieldId === variableId,
+  );
+
+  const variableInfoHandler = (dataFieldId: string) =>
+    setVariableId(dataFieldId);
+
+  const variableInfo = {
+    title: currentVariable?.label || "Invalid label",
+    list: [
+      {
+        label: "Longname",
+        value: currentVariable?.dataFieldLongName ?? "",
+      },
+      {
+        label: "Shortname",
+        value: currentVariable?.dataFieldShortName ?? "",
+      },
+      {
+        label: "Units",
+        value: currentVariable?.dataFieldUnits ?? "",
+      },
+      {
+        label: "Spatial Resolution",
+        value: currentVariable?.dataProductSpatialResolution ?? "",
+      },
+      {
+        label: "Product Name",
+        value: currentVariable?.dataProductShortName ?? "",
+      },
+      {
+        label: "Product Version",
+        value: currentVariable?.dataProductVersion ?? "",
+      },
+      {
+        label: "Begin Datetime",
+        value: currentVariable?.dataProductBeginDateTime
+          ? getDate(currentVariable?.dataProductBeginDateTime)
+          : "",
+      },
+      {
+        label: "End Datetime",
+        value: currentVariable?.dataProductEndDateTime
+          ? getDate(currentVariable?.dataProductEndDateTime)
+          : "",
+      },
+      {
+        label: "Dataset Information",
+        link: currentVariable?.dataProductDescriptionUrl,
+      },
+    ],
+  };
 
   useEffect(() => {
     if (!isOpen) {
@@ -154,11 +211,6 @@ const StorageManager: React.FC<StorageManagerProps> = ({
     }
   };
 
-  const variableInfoHandler = (dataFieldId: string) => {
-    return;
-    // setVariableId(dataFieldId);
-  };
-
   const displayCachedItems = () => {
     if (cachedItems.length === 0) {
       return <p>No data in storage!</p>;
@@ -188,6 +240,8 @@ const StorageManager: React.FC<StorageManagerProps> = ({
     });
   };
 
+  const afterInfoPanelDismiss = () => setVariableId("");
+
   return (
     <IonModal isOpen={isOpen} onDidDismiss={onModalClose}>
       <IonHeader id="storage-header">
@@ -199,11 +253,11 @@ const StorageManager: React.FC<StorageManagerProps> = ({
         </IonToolbar>
       </IonHeader>
       <IonContent className="ion-padding">
-        {/* <InfoPanel
-          // dataList={variableInfo}
-          // isOpen={!!variableId}
-          // afterDismiss={afterInfoPanelDismiss}
-        /> */}
+        <InfoPanel
+          dataList={variableInfo}
+          isOpen={!!variableId}
+          afterDismiss={afterInfoPanelDismiss}
+        />
         <IonCol>
           {usedSpace && totalSpace && (
             <div>

--- a/src/components/Plot/Storage/StorageManager.tsx
+++ b/src/components/Plot/Storage/StorageManager.tsx
@@ -22,11 +22,11 @@ import {
   getDataByKey,
 } from "../../../services/indexDBService";
 import useCheckIndexedDBUsage from "../../../hooks/useCheckIndexedDBUsage";
+import { useCatalogQuery } from "../../../data/useCatalogQuery";
+import { getDate } from "../../../utils/date";
 
 import StorageItem from "./StorageItem";
 import InfoPanel from "../../UI/InfoPanel";
-import { useCatalogQuery } from "../../../data/useCatalogQuery";
-import { getDate } from "../../../utils/date";
 
 interface StorageManagerProps {
   onPlot: (newParams: DataParams) => void;
@@ -48,19 +48,20 @@ const StorageManager: React.FC<StorageManagerProps> = ({
   } = useCheckIndexedDBUsage();
 
   const [cachedItems, setCachedItems] = useState<Partial<VariableDbEntry>[]>(
-    [],
+    []
   );
   const [presentToast, dismissToast] = useIonToast();
   const [presentAlert] = useIonAlert();
 
-  const { data: catalog, isLoading, isFetching } = useCatalogQuery();
-  const [variableId, setVariableId] = useState("");
+  const { data: catalog } = useCatalogQuery();
+  const [infoPanelVariableId, setInfoPanelVariableId] = useState("");
+
   const currentVariable = catalog?.find(
-    (data) => data.dataFieldId === variableId,
+    (data) => data.dataFieldId === infoPanelVariableId
   );
 
   const variableInfoHandler = (dataFieldId: string) =>
-    setVariableId(dataFieldId);
+    setInfoPanelVariableId(dataFieldId);
 
   const variableInfo = {
     title: currentVariable?.label || "Invalid label",
@@ -120,7 +121,7 @@ const StorageManager: React.FC<StorageManagerProps> = ({
   const toastPresenter = (
     message: string,
     position: "top" | "middle" | "bottom",
-    color: "success" | "danger",
+    color: "success" | "danger"
   ) => {
     presentToast({
       message: message,
@@ -136,7 +137,7 @@ const StorageManager: React.FC<StorageManagerProps> = ({
     message?: string,
     subHeader?: string,
     cancel?: () => void,
-    confirm?: (item?: string) => void,
+    confirm?: (item?: string) => void
   ) => {
     presentAlert({
       header: header,
@@ -170,7 +171,7 @@ const StorageManager: React.FC<StorageManagerProps> = ({
       toastPresenter(
         "Something went wrong while retrieving cached data!",
         "top",
-        "danger",
+        "danger"
       );
     }
   };
@@ -190,7 +191,7 @@ const StorageManager: React.FC<StorageManagerProps> = ({
       toastPresenter(
         "Something went wrong while deleting an item!",
         "top",
-        "danger",
+        "danger"
       );
     }
   };
@@ -206,7 +207,7 @@ const StorageManager: React.FC<StorageManagerProps> = ({
       toastPresenter(
         "Something went wrong while deleting items!",
         "top",
-        "danger",
+        "danger"
       );
     }
   };
@@ -231,7 +232,7 @@ const StorageManager: React.FC<StorageManagerProps> = ({
               undefined,
               undefined,
               undefined,
-              () => item.key && deleteCachedItemHandler(item.key),
+              () => item.key && deleteCachedItemHandler(item.key)
             );
           }}
           onRequestInfo={variableInfoHandler}
@@ -239,8 +240,6 @@ const StorageManager: React.FC<StorageManagerProps> = ({
       );
     });
   };
-
-  const afterInfoPanelDismiss = () => setVariableId("");
 
   return (
     <IonModal isOpen={isOpen} onDidDismiss={onModalClose}>
@@ -255,8 +254,8 @@ const StorageManager: React.FC<StorageManagerProps> = ({
       <IonContent className="ion-padding">
         <InfoPanel
           dataList={variableInfo}
-          isOpen={!!variableId}
-          afterDismiss={afterInfoPanelDismiss}
+          isOpen={!!infoPanelVariableId}
+          afterDismiss={() => setInfoPanelVariableId("")}
         />
         <IonCol>
           {usedSpace && totalSpace && (
@@ -276,7 +275,7 @@ const StorageManager: React.FC<StorageManagerProps> = ({
                   undefined,
                   undefined,
                   undefined,
-                  deleteAllItemsHandler,
+                  deleteAllItemsHandler
                 )
               }
               disabled={!cachedItems.length}


### PR DESCRIPTION
This PR adds an info button and slider to storage UI. 

To test this feature:
Go to the "Plot" Tab -> click the Storage button in the top right corner -> a modal window will open with a list of variables (if the list is empty, plot a graph) -> click the info icon next to the variable label.


<img width="340" height="456" alt="Screenshot 2026-02-20 at 12 32 04 PM" 
src="https://github.com/user-attachments/assets/e7757ee8-fbba-4a71-a50f-7e4e7f3f21a8" />

<img width="340" height="456" alt="Screenshot 2026-02-20 at 12 36 41 PM" src="https://github.com/user-attachments/assets/34ac6854-403b-4ee6-9290-ab4b642adfe6" />

